### PR TITLE
Stronger Dayjs typing

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,3 +33,10 @@ On npm: [https://www.npmjs.com/package/@nathanchase/nuxt-dayjs-module](https://w
 
 - Run `npm run dev:prepare` to generate type stubs.
 - Use `npm run dev` to start [playground](./playground) in development mode.
+
+Instantly run dev:
+```bash
+npm install && \
+npm run dev:prepare && \
+npm run dev
+```

--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
   "devDependencies": {
     "@nuxt/module-builder": "latest",
     "@nuxtjs/eslint-config-typescript": "latest",
+    "@types/node": "18.15.11",
     "eslint": "latest",
     "nuxt": "^3.0.0-rc.9"
   }

--- a/playground/app.vue
+++ b/playground/app.vue
@@ -59,13 +59,13 @@ const timezones = ref(['America/New_York',
   'Asia/Taipei'
 ])
 
-const { $dayjs } = useNuxtApp()
+const nuxtApp = useNuxtApp()
 
 const prettyDate = computed(() =>
-  $dayjs(new Date()).format('dddd, MMMM D, YYYY h:mm A')
+  nuxtApp.$dayjs(new Date()).format('dddd, MMMM D, YYYY h:mm A')
 )
 watch(currentLocale, (newVal) => {
-  $dayjs.locale(newVal)
+  nuxtApp.$dayjs.locale(newVal)
 })
 
 </script>

--- a/src/module.ts
+++ b/src/module.ts
@@ -1,5 +1,5 @@
-import { resolve } from 'path'
-import { fileURLToPath } from 'url'
+import { resolve } from 'node:path'
+import { fileURLToPath } from 'node:url'
 import { defineNuxtModule, addPlugin, addTemplate } from '@nuxt/kit'
 import { generateConfigContents } from './gen'
 

--- a/src/runtime/plugin.ts
+++ b/src/runtime/plugin.ts
@@ -1,10 +1,20 @@
 import { defineNuxtPlugin } from '#app'
-import dayjs from 'dayjs/esm/index.js'
 import '#build/dayjs.config.mjs'
+import dayjs from 'dayjs/esm/index.js'
 
+declare module '#app' {
+  interface NuxtApp {
+    $dayjs: typeof dayjs
+  }
+}
+declare module 'vue' {
+  interface ComponentCustomProperties {
+    $dayjs: typeof dayjs
+  }
+}
 declare module '@vue/runtime-core' {
   interface ComponentCustomProperties {
-    $dayjs(date?: dayjs.ConfigType): dayjs.Dayjs
+    $dayjs: typeof dayjs
   }
 }
 


### PR DESCRIPTION
Mostly a fix for the typing of dayjs in general usage. Should resolve https://github.com/nathanchase/dayjs/issues/18

✅  playground works as intended
✅ `npm run prepack` runs as intended with output:
```
> nuxt-module-build

ℹ Building @nathanchase/nuxt-dayjs-module                                                                                                                                                                                                                                         16:08:35
✔ Build succeeded for nuxt-dayjs-module                                                                                                                                                                                                                                           16:08:37
  dist/runtime (total size: 642 B)                                                                                                                                                                                                                                                16:08:37
  └─ dist/runtime/plugin.d.ts (434 B)
  └─ dist/runtime/plugin.mjs (208 B)
  dist/module.mjs (total size: 1.67 kB, chunk size: 1.67 kB, exports: default)                                                                                                                                                                                                    16:08:37

Σ Total dist size (byte size): 3.23 kB

```
Commits:
[* instant run dev command](https://github.com/nathanchase/dayjs/commit/1bfbcafb8b37d50bd82215c7c1d19f889c44583d)
[* do not extract $dayjs from nuxtApp so that template gets the injected type instead of the scripted type from the setup](https://github.com/nathanchase/dayjs/commit/7600000d70db9d98b45e17e664cc8061725516ea)
[* added dayjs typing](https://github.com/nathanchase/dayjs/commit/cf5c7ae739b04da94d17b98b74764e26038ed332)
[* added node types for module path resolving](https://github.com/nathanchase/dayjs/commit/cad0962b59cb522f051e58323f212858b3c437f5)